### PR TITLE
fix(entrypoint-script): removed quotes around EXTRA_ARGS

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,4 +30,4 @@ az storage blob upload-batch \
     --source "${INPUT_SOURCE_PATH}" \
     --destination "${INPUT_CONTAINER_NAME}" \
     --destination-path "${INPUT_DESTINATION_PATH}" \
-    "${EXTRA_ARGS}"
+    ${EXTRA_ARGS}


### PR DESCRIPTION
got quoted, even though it's not an array in this instance, which leads to passing an improper last, empty argument.